### PR TITLE
fix: version in metainfo is not updated

### DIFF
--- a/net.mullvad.MullvadBrowser.metainfo.xml
+++ b/net.mullvad.MullvadBrowser.metainfo.xml
@@ -1,4 +1,3 @@
-<!-- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
     <id>net.mullvad.MullvadBrowser</id>
@@ -24,7 +23,7 @@
     <launchable type="desktop-id">net.mullvad.MullvadBrowser.desktop</launchable>
 
     <releases>
-        <release version="102.9.0esr-12.0-2-build1" date="2023-04-02" />
+        <release version="12.0.6" date="2023-05-17" />
     </releases>
 
     <project_license>MPL-2.0</project_license>


### PR DESCRIPTION
Fixes Flathub page doesn't display correct and updated informations #8