### PR TITLE
fix: `bwrap: execvp mullvad-browser: No such file or directory` in Desktop Actions

### DIFF
--- a/net.mullvad.MullvadBrowser.yml
+++ b/net.mullvad.MullvadBrowser.yml
@@ -4,7 +4,7 @@ runtime-version: &sdk-version '23.08'
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
 base-version: *sdk-version
-command: mullvadbrowser
+command: mullvad-browser
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
@@ -57,7 +57,7 @@ modules:
       - rm Browser/start-mullvad-browser.desktop
 
       - mv Browser/ "${FLATPAK_DEST}/lib/mullvad-browser/"
-      - install -Dm755 mullvad-browser-wrapper "${FLATPAK_DEST}/bin/mullvadbrowser"
+      - install -Dm755 mullvad-browser-wrapper "${FLATPAK_DEST}/bin/mullvad-browser"
       - install -Dm644 firefox.svg "${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg"
       - install -Dm644 distribution.ini "${FLATPAK_DEST}/lib/mullvad-browser/distribution/distribution.ini"
       - install -Dm644 net.mullvad.MullvadBrowser.metainfo.xml "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
@@ -69,9 +69,8 @@ modules:
       # Desktop Entry
       - install -Dm644 net.mullvad.MullvadBrowser.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
       - desktop-file-edit "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
-        --set-key "Exec" --set-value "${FLATPAK_DEST}/bin/mullvadbrowser --detach
-        %u" --set-key "Icon" --set-value "${FLATPAK_ID}" --set-key "Name" --set-value
-        "Mullvad Browser"
+        --set-key "Icon" --set-value "${FLATPAK_ID}"
+        --set-key "Name" --set-value "Mullvad Browser"
     sources:
       - type: archive
         url: https://cdn.mullvad.net/browser/13.0.12/mullvad-browser-linux-x86_64-13.0.12.tar.xz


### PR DESCRIPTION
Fixes https://github.com/flathub/net.mullvad.MullvadBrowser/issues/36