### PR TITLE
Revert "upgrade sdk to 24.08"

### DIFF
--- a/net.mullvad.MullvadBrowser.yml
+++ b/net.mullvad.MullvadBrowser.yml
@@ -1,6 +1,6 @@
 app-id: net.mullvad.MullvadBrowser
 runtime: org.freedesktop.Platform
-runtime-version: &sdk-version '24.08'
+runtime-version: &sdk-version '23.08'
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
 base-version: *sdk-version


### PR DESCRIPTION
Reverts flathub/net.mullvad.MullvadBrowser#53 due to https://github.com/flathub/net.mullvad.MullvadBrowser/issues/54