### PR TITLE
fix: the rectangular icon was used as the launcher icon

### DIFF
--- a/net.mullvad.MullvadBrowser.yml
+++ b/net.mullvad.MullvadBrowser.yml
@@ -58,7 +58,7 @@ modules:
       - mv Browser/ "${FLATPAK_DEST}/lib/mullvad-browser/"
       - install -Dm755 mullvad-browser-wrapper "${FLATPAK_DEST}/bin/mullvad-browser"
       - install -Dm644 "${FLATPAK_DEST}/lib/mullvad-browser/browser/chrome/icons/default/default128.png"
-        "${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.svg"
+        "${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.png"
       - install -Dm644 distribution.ini "${FLATPAK_DEST}/lib/mullvad-browser/distribution/distribution.ini"
       - install -Dm644 net.mullvad.MullvadBrowser.metainfo.xml "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
 


### PR DESCRIPTION
Fixes https://github.com/flathub/net.mullvad.MullvadBrowser/issues/80