### PR TITLE
Update runtime to 25.08

### DIFF
--- a/net.mullvad.MullvadBrowser.yml
+++ b/net.mullvad.MullvadBrowser.yml
@@ -1,16 +1,10 @@
 app-id: net.mullvad.MullvadBrowser
 runtime: org.freedesktop.Platform
-runtime-version: &sdk-version '24.08'
+runtime-version: &sdk-version '25.08'
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
 base-version: *sdk-version
 command: mullvad-browser
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    add-ld-path: .
-    no-autodownload: true
-    version: *sdk-version
 
 finish-args:
   # For webcam
@@ -44,9 +38,6 @@ finish-args:
   - --own-name=org.mozilla.mullvadbrowser.*
   # Player widget: https://gitlab.torproject.org/tpo/applications/mullvad-browser/-/blob/497b87ad9c0af590c418df414024f13bab6a16c6/widget/gtk/MPRISServiceHandler.h#L19
   - --own-name=org.mpris.MediaPlayer2.firefox.*
-
-cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 
 modules:
   - name: mullvad-browser


### PR DESCRIPTION
Also, drop the ffmpeg extension 

> This is supposed to ship in Freedesktop SDK 25.08. The major change for app developers is that there is no longer any need to have something like 

Source: https://bbhtt.in/posts/closing-the-chapter-on-openh264/